### PR TITLE
added alt-text and color contrast fixes to header and history of desserts sections

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -19,7 +19,7 @@
     >
       <div class="flex flex-col gap-4 md:ml-6">
         <p class="text-6xl md:text-left text-center">What's for dessert?</p>
-        <p class="italic text-slate-400">
+        <p class="italic text-orange-950">
           This page has several mistakes which could impact both its
           accessibility and usability! Check out the README in the
           <a

--- a/mistakes.html
+++ b/mistakes.html
@@ -33,6 +33,7 @@
       <img
         class="object-cover w-1/2 rounded-full"
         src="https://upload.wikimedia.org/wikipedia/commons/5/56/Chocolate_cupcakes.jpg"
+        alt="Six chocolate cupcakes with frosting and sprinkles. One cupcake has a bite taken out of it."
       />
     </header>
 

--- a/mistakes.html
+++ b/mistakes.html
@@ -42,7 +42,7 @@
         <h2 class="text-4xl border-b-4 mb-4 border-pink-400">
           History of desserts
         </h2>
-        <p class="italic mb-4 text-slate-400">
+        <p class="italic mb-4 text-pink-800">
           Dessert foods have a rich history, spanning from ancient civilizations
           to modern times. From the ancient Egyptians' honey and fruit
           concoctions, to the intricate pastries of France and gelato


### PR DESCRIPTION
**This PR fixes three accessibility issues found in the mistakes.html file per WCAG guidelines.**

**Issue 1 : Header image did not include alt text**

- _how the error was found_: when reading the HTML file, I noticed that the header image did not have an alt attribute.
- _how it was fixed_: using examples found in the WCAG resource mentioned below, I added alt text to the image.
- _resources used_: [WCAG SC1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content) and [WCAG Technique H37](https://www.w3.org/WAI/WCAG21/Techniques/html/H37)
- _what I learned_: different ways of writing alt text.

**Issue 2 : Second header paragraph text did not pass a color-contrast check**

- _how the error was found_: when using the [WebAIM ContrastChecker](https://webaim.org/resources/contrastchecker/) tool, it indicated that the text color for the second header paragraph did not have enough contrast and failed accessibility guidelines.
- _how it was fixed_: using the same tool, I selected a color from the Tailwind CSS library that did pass these contrast checks, and updated the text with that color.
- _resources used_: [WebAIM ContrastChecker](https://webaim.org/resources/contrastchecker/) and [Tailwind CSS Color Customization](https://tailwindcss.com/docs/customizing-colors)
- _what I learned_: the specific required contrast ratio for each level - 3:1 for the minimum level, 4.5:1 for level AA, and 7:1 for level AAA. The initial contrast ratio for this error was 2.1:1, while the text color in this PR now has a contrast ratio of 12.9:1.

**Issue 3 : History of desserts section text did not pass a color-contrast check**

- _how the error was found_: when using the [WebAIM ContrastChecker](https://webaim.org/resources/contrastchecker/) tool, it indicated that the text color for this section did not have enough contrast and failed accessibility guidelines.
- _how it was fixed_: using the same tool, I selected a color from the Tailwind CSS library that did pass these contrast checks, and updated the text with that color.
- _resources used_: [WebAIM ContrastChecker](https://webaim.org/resources/contrastchecker/) and [Tailwind CSS Color Customization](https://tailwindcss.com/docs/customizing-colors)
- _what I learned_: same as the issue before. The initial contrast ratio for this error was 2.6:1, while the text color in this PR now has a contrast ratio of 7.9:1.